### PR TITLE
added redir functions -m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ SOURCES = \
 		src/handling_redir.c \
 		src/parsing.c \
 		src/tokens_to_array.c \
-		src/builtins/exec_builtin.c \
-		src/execution/test_main.c 
-# src/main.c 
+		src/main.c
+		#src/builtins/exec_builtin.c \
+		#src/execution/test_main.c 
 
 OBJECTS = $(SOURCES:.c=.o)
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -15,10 +15,12 @@
 
 # include "execution.h"
 # include "../libft/libft.h"
-# include <stdio.h> // printf
+# include <stdio.h> // printf, perror
 # include <stdlib.h> // malloc
 # include <readline/readline.h> //readline
 # include <readline/history.h> //readline, add_history
+# include <unistd.h> //dup2
+# include <fcntl.h> //open
 
 # define EMPTY 0
 # define COMMAND 1
@@ -67,6 +69,10 @@ char *handling_quotes(char *input, int *index);
 
 /* handling_redir.c */
 char *redir_symb(char *input, int *index, t_tokens *tokens);
+int	handle_redir_input(const char *file);
+int	handle_redir_output(const char *file);
+int	handle_redir_append(const char *file);
+int	handle_redir_here_doc(const char *delimiter);
 
 /* main.c */
 int	main(int argc, char **argv);

--- a/src/execution/test_main.c
+++ b/src/execution/test_main.c
@@ -47,6 +47,7 @@ static t_command	*init_command(t_tokens *token)
 		{
 			printf("Token string: %s, toke typen: %d, in index %d\n", token[i].token_string, token[i].token_type, i);
 		}
+
 		count++;
 		i++;
 	}

--- a/src/handling_redir.c
+++ b/src/handling_redir.c
@@ -1,5 +1,71 @@
 #include "../includes/minishell.h"
 
+int	handle_redir_input(const char *file)
+{
+	int	fd;
+
+	fd = open(file, O_RDONLY);
+	if (fd < 0)
+	{
+		perror("error");
+		return (-1);
+	}
+	if (dup2(fd, STDIN_FILENO) == -1)
+	{
+		perror("error");
+		close(fd);
+		return (-1);
+	}
+	close(fd);
+	return (1);
+}
+
+int	handle_redir_output(const char *file)
+{
+	int	fd;
+
+	fd = open(file, O_WRONLY | O_TRUNC | O_CREAT, 0644);
+	if (fd < 0)
+	{
+		perror("error");
+		return (-1);
+	}
+	if (dup2(fd, STDOUT_FILENO) == -1)
+	{
+		perror("error");
+		close(fd);
+		return (-1);
+	}
+	close(fd);
+	return (1);
+}
+
+int	handle_redir_append(const char *file)
+{
+	int	fd;
+
+	fd = open(file, O_WRONLY | O_APPEND | O_CREAT, 0644);
+	if (fd < 0)
+	{
+		perror("error");
+		return (-1);
+	}
+	if (dup2(fd, STDOUT_FILENO) == -1)
+	{
+		perror("error");
+		close(fd);
+		return (-1);
+	}
+	close(fd);
+	return (1);
+}
+
+
+/*int	handle_redir_here_doc(const char *delimiter)
+{
+
+}*/
+
 char	*redir_symb(char *input, int *index, t_tokens *tokens)
 {
 	char	*symbol;


### PR DESCRIPTION
lisäsin alku funktiot redirection operations käsittelyille, here-doc en vielä osannut, sitä pitää opiskella lisää ja tehdä myöhemmin. mutta nää funktiot siis nyt vaihdellen redirection tyypistä, avaa filen eri tavalla ja dup2 funktio ns kopioi filen ja tuo sen ohjelmaan sisään sen sijaan että tapahtuisi terminaalissa